### PR TITLE
Return nil for option attributes that are not present instead of raising...

### DIFF
--- a/lib/clever-ruby/clever_object.rb
+++ b/lib/clever-ruby/clever_object.rb
@@ -118,8 +118,13 @@ module Clever
       end
     end
 
+    def optional_attributes
+      raise NotImplementedError.new('Please define #optional_attributes as a list of the attributes on this resource that may not be present and thus should return nil instead of raising a NoMethodError.')
+    end
+
     def method_missing(name, *args)
       return @values[name] if @values.has_key?(name)
+      return nil if optional_attributes.include?(name)
       super
     end
   end

--- a/lib/clever-ruby/district.rb
+++ b/lib/clever-ruby/district.rb
@@ -1,5 +1,10 @@
 module Clever
   class District < APIResource
     include Clever::APIOperations::List
+
+    def optional_attributes
+      # All of a district's attributes are required.
+      []
+    end
   end
 end

--- a/lib/clever-ruby/school.rb
+++ b/lib/clever-ruby/school.rb
@@ -1,5 +1,9 @@
 module Clever
   class School < APIResource
     include Clever::APIOperations::List
+
+    def optional_attributes
+      [:state_id, :sis_id, :nces_id, :low_grade, :high_grade, :principal, :location, :phone]
+    end
   end
 end

--- a/lib/clever-ruby/section.rb
+++ b/lib/clever-ruby/section.rb
@@ -1,5 +1,9 @@
 module Clever
   class Section < APIResource
     include Clever::APIOperations::List
+
+    def optional_attributes
+      [:teacher, :course_name, :course_description, :course_number, :period, :grade, :term]
+    end
   end
 end

--- a/lib/clever-ruby/student.rb
+++ b/lib/clever-ruby/student.rb
@@ -2,6 +2,10 @@ module Clever
   class Student < APIResource
     include Clever::APIOperations::List
 
+    def optional_attributes
+      [:student_number, :state_id, :location, :gender, :dob, :grade, :frl_status, :race, :hispanic_ethnicity, :email]
+    end
+
     def photo
       return @values[:photo] if @values.has_key?(:photo)
       response = Clever.request(:get, photo_url)

--- a/lib/clever-ruby/teacher.rb
+++ b/lib/clever-ruby/teacher.rb
@@ -1,5 +1,9 @@
 module Clever
   class Teacher < APIResource
     include Clever::APIOperations::List
+
+    def optional_attributes
+      [:email, :teacher_number, :title]
+    end
   end
 end

--- a/test/data/vcr_cassettes/schools_optional_attributes.yml
+++ b/test/data/vcr_cassettes/schools_optional_attributes.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://DEMO_KEY:@api.getclever.com/v1.1/schools?
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization,X-Requested-With,Accept,Origin,Referer,User-Agent
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Feb 2013 18:52:47 GMT
+      Etag:
+      - ! '"960244484"'
+      Server:
+      - nginx/1.2.3
+      Set-Cookie:
+      - AWSELB=57FFC5270C5107B6EA5E56398F77D924DD37E7E19953EE4589F0E25E8AB42DE5C42A50E50F0E4B84F1F903CD1F0A4E900C1FA7DA18973A6D0C757C75DBD7DB64ABDE808D68;PATH=/;MAX-AGE=300
+      Strict-Transport-Security:
+      - max-age=500
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '2236'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"data":[{"data":{"district":"4fd43cc56d11340000000005","high_grade":"8","low_grade":"6","name":"Clever
+        Academy","nces_id":"17065379","phone":"1-(755) 019-5442","school_number":"9255","sis_id":"9255","location":{"address":"18828
+        Kutch Court","city":"Dessiemouth","state":"IA","zip":"37471-9969"},"principal":{"email":"eda_barrows@mailinator.com","name":"Colleen
+        Gottlieb"},"last_modified":"2012-11-07T00:44:53.065Z","created":"2012-11-06T00:00:00.000Z","id":"4fee004cca2e43cf27000001"},"uri":"/v1.1/schools/4fee004cca2e43cf27000001"},{"data":{"district":"4fd43cc56d11340000000005","high_grade":"8","low_grade":"6","name":"Clever
+        Preparatory","nces_id":"94755881","phone":"(527) 825-2248","school_number":"2559","sis_id":"2559","state_id":"23","location":{"address":"42139
+        Fadel Mountains","city":"Thomasfort","state":"AP","zip":"61397-3760"},"principal":{"email":"nikolas@mailinator.com","name":"Rudolph
+        Howe"},"last_modified":"2012-11-07T00:44:53.079Z","created":"2012-11-06T00:00:00.000Z","id":"4fee004cca2e43cf27000002"},"uri":"/v1.1/schools/4fee004cca2e43cf27000002"},{"data":{"district":"4fd43cc56d11340000000005","high_grade":"8","low_grade":"6","name":"Clever
+        High School","nces_id":"44270647","phone":"1-(895) 295-3507","school_number":"4083","sis_id":"4083","state_id":"12","location":{"address":"9538
+        Leffler Forks","city":"Gwendolynville","state":"NH","zip":"58530-7427"},"principal":{"email":"domingo_williamson@mailinator.com","name":"Krystal
+        Kiehn"},"last_modified":"2012-11-07T00:44:53.093Z","created":"2012-11-06T00:00:00.000Z","id":"4fee004cca2e43cf27000003"},"uri":"/v1.1/schools/4fee004cca2e43cf27000003"},{"data":{"district":"4fd43cc56d11340000000005","high_grade":"8","low_grade":"6","name":"Clever
+        Memorial High","nces_id":"26309489","phone":"1-(124) 215-8079","school_number":"3935","sis_id":"3935","state_id":"23","location":{"address":"10960
+        Kilback View","city":"North Sarina","state":"MP","zip":"58717-8256"},"principal":{"email":"otto_sanford@mailinator.com","name":"Maryse
+        Tillman"},"last_modified":"2012-11-07T00:44:53.104Z","created":"2012-11-06T00:00:00.000Z","id":"4fee004cca2e43cf27000004"},"uri":"/v1.1/schools/4fee004cca2e43cf27000004"}],"links":[{"rel":"self","uri":"/v1.1/schools"}]}'
+    http_version:
+  recorded_at: Mon, 11 Feb 2013 18:50:38 GMT
+recorded_with: VCR 2.4.0

--- a/test/unit/optional_attributes_test.rb
+++ b/test/unit/optional_attributes_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class OptionalAttributesTest < Test::Unit::TestCase
+  def setup
+    Clever.configure do |config|
+      config.api_key = "DEMO_KEY"
+    end
+
+    VCR.use_cassette("schools_optional_attributes") do
+      @schools = Clever::School.all
+    end
+  end
+
+  should "return nil for an optional attribute that isnt present" do
+    clever_academy = @schools.detect{ |s| s.id == "4fee004cca2e43cf27000001"}
+
+    # Must not raise a NoMethodError.
+    clever_academy.state_id.must_equal nil
+  end
+
+  should "have the expected value for an optional attribute that is present" do
+    clever_prep = @schools.detect{ |s| s.id == "4fee004cca2e43cf27000002"}
+    clever_prep.state_id.must_equal "23"
+  end
+
+  should "raise a NoMethodError for an invalid attribute" do
+    clever_academy = @schools.detect{ |s| s.id == "4fee004cca2e43cf27000001"}
+
+    lambda {
+      clever_academy.some_attribute_that_doesnt_exist
+    }.must_raise NoMethodError
+  end
+end


### PR DESCRIPTION
... a NoMethodError.

This is an intersection of the philosophy of hypermedia and ruby metaprogramming :)

We were running into NoMethodErrors when records did not have some of the optional attributes, which is because the hypermedia api is not returning anything for attributes that don't exist, and the ruby metaprogramming only defines methods for those attributes that exist in the response for that particular instance.

However, we don't want to have to do `if respond_to?(:state_id)` or `rescue NoMethodError` all over our code to handle this case, so in my opinion the methods for optional attributes should return nil (which has its own problems but is less of an issue than an exception).

The new test file `test/unit/optional_attributes_test.rb` now has an example of the behavior I'm advocating for.

I implemented this by adding an `optional_attributes` method in `clever_object` that is meant to be overwritten by the classes that inherit from this and contain a list of the attributes that are optional. I've populated these methods for the existing classes from the schema you've sent us.

I noticed the `@@permanent_attributes` class variable that is read a couple of places but I don't see anyplace that adds to that set-- was that a start to handling this issue?

One thing I've punted on for now is optional nested attributes like teacher name.middle. I think name, location, principal, and term could stand to be made into little Struct objects and then they could handle this issue in their own way, but I wanted to see what you thought of this change before I got too deep.

Thanks!!!!!!
