### PR TITLE
Expose event.previous_attributes

### DIFF
--- a/lib/clever-ruby/event.rb
+++ b/lib/clever-ruby/event.rb
@@ -3,13 +3,17 @@ module Clever
     include Clever::APIOperations::List
 
     def optional_attributes
-      [:previous_attributes]
+      []
     end
 
     def object
       klass = Util.types_to_clever_class(type_pieces[0])
       klass ||= CleverObject
       klass.construct_from(data[:object])
+    end
+
+    def previous_attributes
+      data[:previous_attributes]
     end
 
     def action

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -11,6 +11,20 @@ class EventTest < Test::Unit::TestCase
       },
       id: "512bb9f2ca5e6fa775061340"
     })
+
+    @updated_event = Clever::Event.construct_from({
+      type: "sections.updated",
+      data: {
+        object: {
+          id: "510980c2923bcbba1f0ce5dd"
+        },
+        previous_attributes: {
+          teacher: "510980a6923bcbba1f0cb500",
+          last_modified: "2013-03-11T15:38:58.558Z"
+        }
+      },
+      id: "514767bf80833fb55b1c2dd7"
+    })
   end
 
   should "create a clever object for the object the event is about" do
@@ -19,5 +33,13 @@ class EventTest < Test::Unit::TestCase
 
   should "know what action the event is about (created/updated/deleted)" do
     @event.action.must_equal "created"
+  end
+
+  should "have an empty hash if there aren't previous attributes" do
+    @event.previous_attributes.must_equal {}
+  end
+
+  should "have an event's previous attributes" do
+    @updated_event.previous_attributes[:teacher].must_equal "510980a6923bcbba1f0cb500"
   end
 end


### PR DESCRIPTION
So because we're creating the Clever::Event object using `construct_from(data[:object])` and `previous_attributes` is a sibling and not a child to `data[:object]`, we can't use the existing attribute accessors for `previous_attributes`.

This commit just creates a new implementation for `previous_attributes` that gets the right info.
