### PR TITLE
Fix error handling bugs

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -23,8 +23,11 @@ require 'clever-ruby/event'
 
 # Errors
 require 'clever-ruby/errors/clever_error'
-require 'clever-ruby/errors/authentication_error'
+
+require 'clever-ruby/errors/api_connection_error'
 require 'clever-ruby/errors/api_error'
+require 'clever-ruby/errors/authentication_error'
+require 'clever-ruby/errors/invalid_request_error'
 
 module Clever
   class << self


### PR DESCRIPTION
So we were sending some bad requests to Clever that then hit some error handling code in clever-ruby, which exposed that there are some bugs in the error handling code.

One I introduced when I changed `@@api_base` to be replaced by `configuration.api_base` but `@@api_base` was still being referenced in an error message. I'm sorry; I should have searched and made sure I caught all of those. I don't see any remaining.

The other issue is not all of the error classes were being required in the main clever-ruby file.

Thanks and sorry again!!!
