### PR TITLE
URI encode query params when constructing the query string

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -1,5 +1,6 @@
 require 'rest_client'
 require 'multi_json'
+require 'open-uri'
 
 require 'clever-ruby/version'
 
@@ -49,6 +50,16 @@ module Clever
     end
   end
 
+  def self.convert_to_query_string(params = nil)
+    if params && params.count
+      "?" + Util.flatten_params(params).collect { |p|
+        "#{URI::encode(p[0].to_s)}=#{URI::encode(p[1].to_s)}"
+      }.join('&')
+    else
+      ''
+    end
+  end
+
   def self.request(method, url, params=nil, headers={})
     raise AuthenticationError.new('No API key provided. (HINT: set your API key using "Clever.configure { |config| config.api_key = <API-KEY> }")') unless Clever.api_key
 
@@ -57,11 +68,7 @@ module Clever
 
     case method.to_s.downcase.to_sym
     when :get, :head, :delete
-      # Make params into GET parameters
-      if params && params.count
-        query_string = Util.flatten_params(params).collect{|p| "#{p[0]}=#{p[1]}"}.join('&')
-        url += "?#{query_string}"
-      end
+      url += convert_to_query_string(params)
       payload = nil
     else
       payload = params

--- a/test/unit/clever_test.rb
+++ b/test/unit/clever_test.rb
@@ -14,4 +14,11 @@ class CleverTest < Test::Unit::TestCase
     assert_equal("https://api.getclever.com/v1.1/sections", Clever.resource_url("sections"))
     assert_equal("https://api.getclever.com/v1.1/teachers", Clever.resource_url("teachers"))
   end
+
+  should "uri-encode params" do
+    query_string = Clever.convert_to_query_string({
+      created_at: '2013-02-15T 2:30:42Z'
+    })
+    query_string.must_equal "?created_at=2013-02-15T%202:30:42Z"
+  end
 end


### PR DESCRIPTION
So I sent a created_since with a timestamp with a space in it accidentally and got a URI::InvalidURIError... and I've since fixed the date formatting since the W3C DTF format isn't supposed to have spaces in it anyway, but URI encoding params is a better thing to do when constructing URLs.
