### PR TITLE
Handle InvalidRequestError responses that don't contain a param

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -163,7 +163,11 @@ module Clever
   end
 
   def self.invalid_request_error(error, rcode, rbody, error_obj)
-    InvalidRequestError.new(error[:message], error[:param], rcode, rbody, error_obj)
+    if error.is_a? Hash
+      InvalidRequestError.new(error[:message], error[:param], rcode, rbody, error_obj)
+    else
+      InvalidRequestError.new(error, '', rcode, rbody, error_obj)
+    end
   end
 
   def self.authentication_error(error, rcode, rbody, error_obj)

--- a/test/data/vcr_cassettes/error_handling.yml
+++ b/test/data/vcr_cassettes/error_handling.yml
@@ -1,0 +1,184 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://DEMO_KEY:@api.getclever.com/v1.1/districts?
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization,X-Requested-With,Accept,Origin,Referer,User-Agent
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2013 17:09:46 GMT
+      Server:
+      - nginx/1.2.7
+      Set-Cookie:
+      - AWSELB=A91137730E0ED0C3FE64858C01B7DE99906AE563A8CD7BD1CCF9B10870E96BC42024E91EFF14E7F99B23B8AEDFFF8573F9B41FB375FD4A8FC6C6CAF12129D54C280B596A87;PATH=/;MAX-AGE=300
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '174'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"data":[{"data":{"name":"Demo District","id":"4fd43cc56d11340000000005"},"uri":"/v1.1/districts/4fd43cc56d11340000000005"}],"links":[{"rel":"self","uri":"/v1.1/districts"}]}'
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 17:09:35 GMT
+- request:
+    method: get
+    uri: https://DEMO_KEY:@api.getclever.com/v1.1/districts/4fd43cc56d11340000000005
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization,X-Requested-With,Accept,Origin,Referer,User-Agent
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2013 17:09:46 GMT
+      Server:
+      - nginx/1.2.7
+      Set-Cookie:
+      - AWSELB=A91137730E0ED0C3FE64858C01B7DE99906AE563A8CD7BD1CCF9B10870E96BC42024E91EFF14E7F99B23B8AEDFFF8573F9B41FB375FD4A8FC6C6CAF12129D54C280B596A87;PATH=/;MAX-AGE=300
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '599'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"data":{"name":"Demo District","id":"4fd43cc56d11340000000005"},"links":[{"rel":"self","uri":"/v1.1/districts/4fd43cc56d11340000000005"},{"rel":"schools","uri":"/v1.1/districts/4fd43cc56d11340000000005/schools"},{"rel":"teachers","uri":"/v1.1/districts/4fd43cc56d11340000000005/teachers"},{"rel":"students","uri":"/v1.1/districts/4fd43cc56d11340000000005/students"},{"rel":"sections","uri":"/v1.1/districts/4fd43cc56d11340000000005/sections"},{"rel":"properties","uri":"/v1.1/districts/4fd43cc56d11340000000005/properties"},{"rel":"events","uri":"/v1.1/districts/4fd43cc56d11340000000005/events"}]}'
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 17:09:36 GMT
+- request:
+    method: get
+    uri: https://DEMO_KEY:@api.getclever.com/v1.1/districts/4fd43cc56d11340000000005
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization,X-Requested-With,Accept,Origin,Referer,User-Agent
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2013 17:09:46 GMT
+      Server:
+      - nginx/1.2.7
+      Set-Cookie:
+      - AWSELB=A91137730E0ED0C3FE64858C01B7DE99906AE563A8CD7BD1CCF9B10870E96BC42024E91EFF14E7F99B23B8AEDFFF8573F9B41FB375FD4A8FC6C6CAF12129D54C280B596A87;PATH=/;MAX-AGE=300
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '599'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"data":{"name":"Demo District","id":"4fd43cc56d11340000000005"},"links":[{"rel":"self","uri":"/v1.1/districts/4fd43cc56d11340000000005"},{"rel":"schools","uri":"/v1.1/districts/4fd43cc56d11340000000005/schools"},{"rel":"teachers","uri":"/v1.1/districts/4fd43cc56d11340000000005/teachers"},{"rel":"students","uri":"/v1.1/districts/4fd43cc56d11340000000005/students"},{"rel":"sections","uri":"/v1.1/districts/4fd43cc56d11340000000005/sections"},{"rel":"properties","uri":"/v1.1/districts/4fd43cc56d11340000000005/properties"},{"rel":"events","uri":"/v1.1/districts/4fd43cc56d11340000000005/events"}]}'
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 17:09:36 GMT
+- request:
+    method: get
+    uri: https://DEMO_KEY:@api.getclever.com//v1.1/districts/4fd43cc56d11340000000005/events?created_since=2013-02-15T%202:30:42%200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - ! '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization,X-Requested-With,Accept,Origin,Referer,User-Agent
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Cache-Control:
+      - no-cache="set-cookie"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2013 17:09:47 GMT
+      Server:
+      - nginx/1.2.7
+      Set-Cookie:
+      - AWSELB=A91137730E0ED0C3FE64858C01B7DE99906AE563A8CD7BD1CCF9B10870E96BC42024E91EFF14E7F99B23B8AEDFFF8573F9B41FB375FD4A8FC6C6CAF12129D54C280B596A87;PATH=/;MAX-AGE=300
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '174'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"error":"Could not parse created_since ''2013-02-15T 2:30:42 0000''.
+        Please ensure it is either a valid ObjectID or a valid W3C datetime: http://www.w3.org/TR/NOTE-datetime."}'
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 17:09:36 GMT
+recorded_with: VCR 2.4.0

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ErrorHandlingTest < Test::Unit::TestCase
+  def setup
+    Clever.configure do |config|
+      config.api_key = "DEMO_KEY"
+    end
+  end
+
+  should "raise an InvalidRequestError when given a bad created_since" do
+    VCR.use_cassette("error_handling") do
+      @district = Clever::District.all.first
+      lambda {
+        @district.events(created_since: '2013-02-15T 2:30:42 0000')
+      }.must_raise Clever::InvalidRequestError
+    end
+  end
+end


### PR DESCRIPTION
Before this change, the test fails with TypeError instead because the error handling code is trying to index into a string because it expects a hash.

I'm guessing the error json changed at some point? I think this should handle both ways in case you change your mind, but if you've solidified the way you're representing errors and will only ever send one way, let me know and I'll be happy to update this PR.

Thanks!!! <3
