### PR TITLE
Fix urls for Event type object and remove unused code

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -1,6 +1,7 @@
 require 'rest_client'
 require 'multi_json'
 require 'open-uri'
+require 'set'
 
 require 'clever-ruby/version'
 
@@ -42,10 +43,6 @@ module Clever
 
     def configuration
       @configuration ||= Clever::Configuration.new
-    end
-
-    def resource_url(resource_name = '')
-      configuration.api_base + 'v1.1/' + resource_name
     end
 
     def api_url(url = '')

--- a/lib/clever-ruby/event.rb
+++ b/lib/clever-ruby/event.rb
@@ -19,6 +19,10 @@ module Clever
     def action
       type_pieces[1]
     end
+    
+    def self.url
+      "v1.1/push/events"
+    end
 
     private
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,9 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","lib"))
+
 require 'minitest/autorun'
 require 'shoulda'
 require 'vcr'
 require 'clever-ruby'
-
 
 VCR.configure do |c|
   c.cassette_library_dir = 'test/data/vcr_cassettes'

--- a/test/unit/clever_test.rb
+++ b/test/unit/clever_test.rb
@@ -7,12 +7,13 @@ class CleverTest < Test::Unit::TestCase
     end
   end
 
-  should "return top-level resource urls" do
-    assert_equal("https://api.getclever.com/v1.1/districts", Clever.resource_url("districts"))
-    assert_equal("https://api.getclever.com/v1.1/schools", Clever.resource_url("schools"))
-    assert_equal("https://api.getclever.com/v1.1/students", Clever.resource_url("students"))
-    assert_equal("https://api.getclever.com/v1.1/sections", Clever.resource_url("sections"))
-    assert_equal("https://api.getclever.com/v1.1/teachers", Clever.resource_url("teachers"))
+  should "returns correct urls for Resources" do
+    assert_equal("v1.1/districts", Clever::District.url)
+    assert_equal("v1.1/schools", Clever::School.url)
+    assert_equal("v1.1/students", Clever::Student.url)
+    assert_equal("v1.1/sections", Clever::Section.url)
+    assert_equal("v1.1/teachers", Clever::Teacher.url)
+    assert_equal("v1.1/push/events", Clever::Event.url)
   end
 
   should "uri-encode params" do


### PR DESCRIPTION
Current version of clever-ruby does not allow you to fetch events. Fixed that and removed an unused method (with it's tests).
