### PR TITLE
Fix API error handling

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -180,10 +180,10 @@ module Clever
   end
 
   def self.authentication_error(error, rcode, rbody, error_obj)
-    AuthenticationError.new(error[:message], rcode, rbody, error_obj)
+    AuthenticationError.new(error, rcode, rbody, error_obj)
   end
 
   def self.api_error(error, rcode, rbody, error_obj)
-    APIError.new(error[:message], rcode, rbody, error_obj)
+    APIError.new(error.is_a?(Hash) ? error[:message] : error, rcode, rbody, error_obj)
   end
 end


### PR DESCRIPTION
When authentication fails, it returns `"{\"error\":\"Unrecognized API key\"}"`. The error handling code tried to read error[:message], which would throw a TypeError since error is just the string "Unrecognized API key".

Many people probably hit this problem because Clever Dev docs tell you to use DEMO_TOKEN as your API key, when you actually have to use it as your token or use DEMO_KEY as your API key.

I wasn't sure what other API errors look like, so I check if it's a hash before looking for message.