### PR TITLE
Extract linked resources to APIObject and use it everywhere

### DIFF
--- a/lib/clever-ruby/api_resource.rb
+++ b/lib/clever-ruby/api_resource.rb
@@ -31,5 +31,17 @@ module Clever
       instance.refresh
       instance
     end
+
+    private
+
+    def get_linked_resources(resource_type, filters={})
+      Util.convert_to_clever_object(Clever.request(:get, get_uri(resource_type), filters)[:data])
+    end
+
+    def get_uri(resource_type)
+      refresh
+      links.detect {|link| link[:rel] == resource_type }[:uri]
+    end
+
   end
 end

--- a/lib/clever-ruby/district.rb
+++ b/lib/clever-ruby/district.rb
@@ -19,15 +19,5 @@ module Clever
       end
     end
 
-    private
-
-    def get_linked_resources(resource_type, filters={})
-      Util.convert_to_clever_object(Clever.request(:get, get_uri(resource_type), filters)[:data])
-    end
-
-    def get_uri(resource_type)
-      refresh
-      links.detect {|link| link[:rel] == resource_type }[:uri]
-    end
   end
 end

--- a/lib/clever-ruby/school.rb
+++ b/lib/clever-ruby/school.rb
@@ -5,5 +5,18 @@ module Clever
     def optional_attributes
       [:state_id, :sis_id, :nces_id, :low_grade, :high_grade, :principal, :location, :phone]
     end
+
+    [:teachers, :students, :sections].each do |name|
+      define_method(name) do |filters = {}|
+        get_linked_resources name.to_s, filters
+      end
+    end
+
+    [:teacher_pages, :student_pages, :section_pages].each do |name|
+      define_method(name) do |filters = {}|
+        Clever::APIOperations::PageList.new(get_uri(name.to_s.gsub('_page', '')), filters)
+      end
+    end
+
   end
 end

--- a/lib/clever-ruby/student.rb
+++ b/lib/clever-ruby/student.rb
@@ -12,6 +12,18 @@ module Clever
       @values[:photo] = response[:data][:data]
     end
 
+    [:sections, :school, :district, :teachers].each do |name|
+      define_method(name) do |filters = {}|
+        get_linked_resources name.to_s, filters
+      end
+    end
+
+    [:section_pages, :teachers_pages].each do |name|
+      define_method(name) do |filters = {}|
+        Clever::APIOperations::PageList.new(get_uri(name.to_s.gsub('_page', '')), filters)
+      end
+    end
+
     private
 
     def photo_url

--- a/lib/clever-ruby/teacher.rb
+++ b/lib/clever-ruby/teacher.rb
@@ -5,5 +5,18 @@ module Clever
     def optional_attributes
       [:email, :teacher_number, :title]
     end
+
+    [:sections, :school, :district, :teachers].each do |name|
+      define_method(name) do |filters = {}|
+        get_linked_resources name.to_s, filters
+      end
+    end
+
+    [:section_pages, :teachers_pages].each do |name|
+      define_method(name) do |filters = {}|
+        Clever::APIOperations::PageList.new(get_uri(name.to_s.gsub('_page', '')), filters)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This allows schools, students, and teachers to use the same linked_resources functionality that was previously present only in districts.
