### PR TITLE
Make drone target ruby 2.0.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: ruby1.9.3
+image: ruby2.0.0
 script:
   - bundle install
   - bundle exec rake


### PR DESCRIPTION
* Dockerhub [still doesn't have support for anything newer](https://hub.docker.com/r/bradrydzewski/ruby/tags/)
* Ruby 1.9.3 [is no longer supported](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)
* Drone [doesn't support multiple tested versions yet](https://github.com/drone/drone/issues/6)

Hence, target Ruby 2.0.0 now.