### PR TITLE
Remove ActiveSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0 (2015-09-28)
+
+* Remove inflector dependency
+
 ## 0.11.1 (2015-09-28)
 
 * Fix APIError throwing a TypeError when API requests fail

--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'multi_json',    '~> 1.10.0'
   gem.add_runtime_dependency 'rest-client',   '~> 1.6.7'
-  gem.add_runtime_dependency 'activesupport', '~> 4.2.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest',      '~> 5.4.1'

--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -1,7 +1,6 @@
 # rubocop:disable FileName
 require 'rest_client'
 require 'multi_json'
-require 'active_support/inflector'
 require 'open-uri'
 require 'set'
 require 'uri'

--- a/lib/clever-ruby/api_resource.rb
+++ b/lib/clever-ruby/api_resource.rb
@@ -15,14 +15,17 @@ module Clever
       # @return [Array] List of resources nested under this resource
       attr_reader :linked_resources
 
-      # Get the plural form of a resource's name. For instance, for class
-      # Student, this would return "students".
+      # Get the plural form of a resource's name
+      #
+      # For instance, for class Student, returns "students"
       # @api private
       # @return [String] Plural name of a resource
       attr_reader :plural
 
-      # Get the URI corresponding to a resource. For instance, for class
-      # Student, urls start with /v1.1/students, so this returns "students"
+      # Get the URI corresponding to a resource
+      #
+      # For instance, for class Student, urls start with /v1.1/students, so
+      # this returns "students"
       # @api private
       # @return [String] URI corresponding to a resource
       attr_reader :uri
@@ -36,9 +39,10 @@ module Clever
       super
     end
 
-    # Check if the name of an APIResource is in its singular
-    # form. For instance, the Student API resource can be "student"
-    # or "students".
+    # Check if the name of an APIResource is in its singular form
+    #
+    # For instance, the Student API resource can be referred to as
+    # "student" or "students"; this returns true on the former.
     # @api private
     # @param word [String] APIResource name to check
     # @return [Boolean] False if plural, true if singular

--- a/lib/clever-ruby/api_resource.rb
+++ b/lib/clever-ruby/api_resource.rb
@@ -1,5 +1,6 @@
 module Clever
-  # Superclass of API resources in the Clever API
+  # Superclass of API resources in the Clever API. API objects are to be
+  # singular, not plural; as in class Student, for the /students endpoint.
   class APIResource < CleverObject
     @resources = []
 
@@ -13,6 +14,18 @@ module Clever
       # @api private
       # @return [Array] List of resources nested under this resource
       attr_reader :linked_resources
+
+      # Get the plural form of a resource's name. For instance, for class
+      # Student, this would return "students".
+      # @api private
+      # @return [String] Plural name of a resource
+      attr_reader :plural
+
+      # Get the URI corresponding to a resource. For instance, for class
+      # Student, urls start with /v1.1/students, so this returns "students"
+      # @api private
+      # @return [String] URI corresponding to a resource
+      attr_reader :uri
     end
 
     # Registers valid API resources
@@ -23,19 +36,38 @@ module Clever
       super
     end
 
+    # Check if the name of an APIResource is in its singular
+    # form. For instance, the Student API resource can be "student"
+    # or "students".
+    # @api private
+    # @param word [String] APIResource name to check
+    # @return [Boolean] False if plural, true if singular
+    def self.singular?(resource_name)
+      klass = named resource_name
+      unless klass
+        fail 'Clever::APIResource only supports checking singularity of words '\
+          'that refer to children of Clever::APIResource; received ' \
+          "'#{resource_name}'"
+      end
+
+      klass.plural != resource_name.downcase
+    end
+
+
     # Get a canonical name for a resource
     # @api private
     # @return [String]
     def self.shortname
-      name.split('::')[-1].downcase.singularize
+      name.split('::')[-1].downcase
     end
 
-    # Convert the name of a resource to its APIResource subclass
+    # Convert the uri of a resource to its APIResource subclass
     # @api private
     # @return [APIResource]
     def self.named(name)
-      name = name.to_s.downcase.singularize
-      matching = resources.select { |res| res.shortname == name }
+      name = name.to_s.downcase
+      matching = resources.select { |res|
+        (name == res.shortname) || (name == res.plural) }
       return nil if matching.empty?
       matching.first
     end
@@ -48,7 +80,7 @@ module Clever
         fail NotImplementedError, 'APIResource is an abstract class. You should perform actions '\
           'on its subclasses (School, Student, etc.)'
       end
-      "v1.1/#{CGI.escape shortname.pluralize}"
+      "v1.1/#{uri}"
     end
 
     # Get URL for an instance of a resource
@@ -112,7 +144,7 @@ module Clever
       return if self.class.linked_resources.nil?
 
       self.class.linked_resources.each do |resource|
-        if Clever::Util.singular? resource.to_s
+        if APIResource.singular? resource.to_s
           # Get single resource
           self.class.send :define_method, resource do
             response = Clever.request :get, get_link_uri(resource), {}, headers

--- a/lib/clever-ruby/api_resource.rb
+++ b/lib/clever-ruby/api_resource.rb
@@ -53,7 +53,6 @@ module Clever
       klass.plural != resource_name.downcase
     end
 
-
     # Get a canonical name for a resource
     # @api private
     # @return [String]
@@ -66,8 +65,9 @@ module Clever
     # @return [APIResource]
     def self.named(name)
       name = name.to_s.downcase
-      matching = resources.select { |res|
-        (name == res.shortname) || (name == res.plural) }
+      matching = resources.select do |res|
+        (name == res.shortname) || (name == res.plural)
+      end
       return nil if matching.empty?
       matching.first
     end

--- a/lib/clever-ruby/district.rb
+++ b/lib/clever-ruby/district.rb
@@ -2,6 +2,8 @@ module Clever
   # District resource
   class District < APIResource
     include Clever::APIOperations::List
+    @plural = 'districts'
+    @uri = 'districts'
     @linked_resources = [:schools, :teachers, :sections, :students, :events]
 
     # Get admins for the current district

--- a/lib/clever-ruby/event.rb
+++ b/lib/clever-ruby/event.rb
@@ -2,6 +2,8 @@ module Clever
   # Event resource
   class Event < APIResource
     include Clever::APIOperations::List
+    @uri = 'events'
+    @plural = 'events'
 
     # Optional attributes
     # @see Clever::CleverObject.optional_attributes

--- a/lib/clever-ruby/school.rb
+++ b/lib/clever-ruby/school.rb
@@ -2,6 +2,8 @@ module Clever
   # School resource
   class School < APIResource
     include Clever::APIOperations::List
+    @uri = 'schools'
+    @plural = 'schools'
     @linked_resources = [:students, :district, :sections, :teachers, :events]
 
     # Optional attributes

--- a/lib/clever-ruby/section.rb
+++ b/lib/clever-ruby/section.rb
@@ -2,6 +2,8 @@ module Clever
   # Section resource
   class Section < APIResource
     include Clever::APIOperations::List
+    @uri = 'sections'
+    @plural = 'sections'
     @linked_resources = [:school, :district, :students, :teacher, :events]
 
     # Optional attributes

--- a/lib/clever-ruby/student.rb
+++ b/lib/clever-ruby/student.rb
@@ -2,6 +2,8 @@ module Clever
   # Student resource
   class Student < APIResource
     include Clever::APIOperations::List
+    @uri = 'students'
+    @plural = 'students'
     @linked_resources = [:school, :district, :sections, :teachers, :events]
 
     # Get contacts for the current student

--- a/lib/clever-ruby/teacher.rb
+++ b/lib/clever-ruby/teacher.rb
@@ -2,6 +2,8 @@ module Clever
   # Teacher resource
   class Teacher < APIResource
     include Clever::APIOperations::List
+    @uri = 'teachers'
+    @plural = 'teachers'
     @linked_resources = [:school, :district, :students, :sections, :events]
 
     # Optional attributes

--- a/lib/clever-ruby/util.rb
+++ b/lib/clever-ruby/util.rb
@@ -1,14 +1,6 @@
 module Clever
   # Library helper methods
   module Util
-    # Check if a given word is singular
-    # @api private
-    # @param word [String] Word to check
-    # @return [Boolean] False if plural, true if singular
-    def self.singular?(word)
-      word.singularize == word
-    end
-
     # Check if a given ID is a valid format (MongoDB BSON ObjectID)
     # @api private
     # @param id [String] ID to check

--- a/lib/clever-ruby/version.rb
+++ b/lib/clever-ruby/version.rb
@@ -2,5 +2,5 @@
 module Clever
   # Version. Follows semantic versioning, as described here:
   # http://semver.org/
-  VERSION = '0.11.1'
+  VERSION = '0.12.0'
 end

--- a/test/integration/last_test.rb
+++ b/test/integration/last_test.rb
@@ -30,7 +30,7 @@ describe 'last method', :vcr do
         resource.linked_resources do |l|
           nested = resource.first.send l
           nested_resource = Clever::APIResource.named l
-          if Clever::Util.singular? l
+          if Clever::APIResource.singular? l
             nested.first.must_be_instance_of nested_resource
           else
             nested.first.must_be_instance_of nested_resource

--- a/test/integration/nested_resource_test.rb
+++ b/test/integration/nested_resource_test.rb
@@ -13,7 +13,7 @@ describe Clever::NestedResource, :vcr do
     resource.linked_resources.each do |link|
       it "retrieves a #{resource.shortname}'s #{link}" do
         result = resource.find.first.send link
-        if Clever::Util.singular?(link.to_s)
+        if Clever::APIResource.singular?(link.to_s)
           result.must_be_instance_of Clever::APIResource.named(link.to_s)
         else
           result.must_be_instance_of Clever::NestedResource

--- a/test/unit/api_resource_test.rb
+++ b/test/unit/api_resource_test.rb
@@ -1,16 +1,29 @@
 require 'test_helper'
 
 describe Clever::APIResource do
-  describe :named do
-    let :resources do
-      { district: { plural: 'districts', klass: Clever::District },
-        school: { plural: 'schools', klass: Clever::School },
-        section: { plural: 'sections', klass: Clever::Section },
-        event: { plural: 'events', klass: Clever::Event },
-        teacher: { plural: 'teachers', klass: Clever::Teacher },
-        student: { plural: 'students', klass: Clever::Student } }
+  let :resources do
+    { district: { plural: 'districts', klass: Clever::District },
+      school: { plural: 'schools', klass: Clever::School },
+      section: { plural: 'sections', klass: Clever::Section },
+      event: { plural: 'events', klass: Clever::Event },
+      teacher: { plural: 'teachers', klass: Clever::Teacher },
+      student: { plural: 'students', klass: Clever::Student } }
+  end
+
+  describe :singular do
+    it 'identifies singular and plural resource names' do
+      resources.each do |singular, klass_info|
+        Clever::APIResource.singular?(singular).must_equal true
+        Clever::APIResource.singular?(klass_info[:plural]).must_equal false
+      end
     end
 
+    it 'fails on non-resource names' do
+      -> { Clever::APIResource.singular?('thing') }.must_raise RuntimeError
+    end
+  end
+
+  describe :named do
     it 'returns nil on nonexistent resources' do
       Clever::APIResource.named('fake_resource').must_equal nil
     end

--- a/test/unit/api_resource_test.rb
+++ b/test/unit/api_resource_test.rb
@@ -3,12 +3,12 @@ require 'test_helper'
 describe Clever::APIResource do
   describe :named do
     let :resources do
-      { district: Clever::District,
-        school: Clever::School,
-        section: Clever::Section,
-        event: Clever::Event,
-        teacher: Clever::Teacher,
-        student: Clever::Student }
+      { district: { plural: 'districts', klass: Clever::District },
+        school: { plural: 'schools', klass: Clever::School },
+        section: { plural: 'sections', klass: Clever::Section },
+        event: { plural: 'events', klass: Clever::Event },
+        teacher: { plural: 'teachers', klass: Clever::Teacher },
+        student: { plural: 'students', klass: Clever::Student } }
     end
 
     it 'returns nil on nonexistent resources' do
@@ -16,16 +16,17 @@ describe Clever::APIResource do
     end
 
     it 'returns valid responses for both symbol and string inputs' do
-      resources.each do |res_name, klass|
-        Clever::APIResource.named(res_name.to_s).must_equal klass
-        Clever::APIResource.named(res_name.to_sym).must_equal klass
+      resources.each do |res_name, klass_info|
+        Clever::APIResource.named(res_name.to_s).must_equal klass_info[:klass]
+        Clever::APIResource.named(res_name.to_sym).must_equal klass_info[:klass]
       end
     end
 
     it 'returns valid responses for both singular and plural words' do
-      resources.each do |res_name, klass|
-        Clever::APIResource.named(res_name.to_s).must_equal klass
-        Clever::APIResource.named(res_name.to_s.pluralize).must_equal klass
+      resources.each do |res_name, klass_info|
+        Clever::APIResource.named(res_name.to_s).must_equal klass_info[:klass]
+        Clever::APIResource.named(
+          klass_info[:plural]).must_equal klass_info[:klass]
       end
     end
   end


### PR DESCRIPTION
It was used for the inflector, but it causes versioning issues when dealing with Rails. It is way more heavy duty than necessary—so just hard encode plural forms for each resource.

URIs, although always the same as plurals right now, are also hard-encoded; while that invariant has been true in the past they're separate concepts and don't need to be mixed.

Closes #61 