### PR TITLE
Fix exception in #72

### DIFF
--- a/lib/clever-ruby/api_resource.rb
+++ b/lib/clever-ruby/api_resource.rb
@@ -29,6 +29,14 @@ module Clever
       # @api private
       # @return [String] URI corresponding to a resource
       attr_reader :uri
+
+      # Get the event name corresponding to a resource
+      #
+      # For some events, event type names have an inconsistent format with plurals and URIs.
+      # For example, SchoolAdmin events are "schooladmins"
+      # @api private
+      # @return [String] event type name of a resource
+      attr_reader :event_name
     end
 
     # Registers valid API resources
@@ -70,7 +78,7 @@ module Clever
     def self.named(name)
       name = name.to_s.downcase
       matching = resources.select do |res|
-        (name == res.shortname) || (name == res.plural)
+        (name == res.shortname) || (name == res.plural) || (name == res.event_name)
       end
       return nil if matching.empty?
       matching.first

--- a/lib/clever-ruby/school_admin.rb
+++ b/lib/clever-ruby/school_admin.rb
@@ -4,6 +4,8 @@ module Clever
     include Clever::APIOperations::List
     @uri = 'school_admins'
     @plural = 'school_admins'
+    @event_name = 'schooladmins'
+
     @linked_resources = [:schools]
 
     # Optional attributes

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -42,5 +42,16 @@ describe Clever::Event do
     end
   end
 
+  describe 'school admin events' do
+    it 'creates a clever object for the object the event is about' do
+      @event = Clever::Event.construct_from(
+        type: 'schooladmins.created',
+        data: {
+          object: { id: '512bb9f2ca5e6fa77506133f' }
+        },
+        id: '512bb9f2ca5e6fa775061340'
+      )
+      @event.object.must_be_instance_of Clever::SchoolAdmin
+    end
   end
 end

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -2,41 +2,45 @@ require 'test_helper'
 
 # test events resource
 describe Clever::Event do
-  before do
-    @event = Clever::Event.construct_from(
-      type: 'sections.created',
-      data: {
-        object: { id: '512bb9f2ca5e6fa77506133f' }
-      },
-      id: '512bb9f2ca5e6fa775061340'
-    )
+  describe 'section events' do
+    before do
+      @event = Clever::Event.construct_from(
+        type: 'sections.created',
+        data: {
+          object: { id: '512bb9f2ca5e6fa77506133f' }
+        },
+        id: '512bb9f2ca5e6fa775061340'
+      )
 
-    @updated_event = Clever::Event.construct_from(
-      type: 'sections.updated',
-      data: {
-        object: { id: '510980c2923bcbba1f0ce5dd' },
-        previous_attributes: {
-          teacher: '510980a6923bcbba1f0cb500',
-          last_modified: '2013-03-11T15:38:58.558Z'
-        }
-      },
-      id: '514767bf80833fb55b1c2dd7'
-    )
+      @updated_event = Clever::Event.construct_from(
+        type: 'sections.updated',
+        data: {
+          object: { id: '510980c2923bcbba1f0ce5dd' },
+          previous_attributes: {
+            teacher: '510980a6923bcbba1f0cb500',
+            last_modified: '2013-03-11T15:38:58.558Z'
+          }
+        },
+        id: '514767bf80833fb55b1c2dd7'
+      )
+    end
+
+    it 'creates a clever object for the object the event is about' do
+      @event.object.must_be_instance_of Clever::Section
+    end
+
+    it 'knows what action the event is about (created/updated/deleted)' do
+      @event.action.must_equal 'created'
+    end
+
+    it "returns an empty hash if there aren't previous attributes" do
+      @event.previous_attributes.must_equal {}
+    end
+
+    it "has an event's previous attributes" do
+      @updated_event.previous_attributes[:teacher].must_equal '510980a6923bcbba1f0cb500'
+    end
   end
 
-  it 'creates a clever object for the object the event is about' do
-    @event.object.must_be_instance_of Clever::Section
-  end
-
-  it 'knows what action the event is about (created/updated/deleted)' do
-    @event.action.must_equal 'created'
-  end
-
-  it "returns an empty hash if there aren't previous attributes" do
-    @event.previous_attributes.must_equal {}
-  end
-
-  it "has an event's previous attributes" do
-    @updated_event.previous_attributes[:teacher].must_equal '510980a6923bcbba1f0cb500'
   end
 end


### PR DESCRIPTION
As describe in the slack channel:

The issue comes down to that the clever-ruby gem expects school admin events to be of type ‘school_admins’, not ‘schooladmins’. e.g. ‘school_admins.created’ instead of ‘schooladmins.created’. However, this isn’t what the clever API is returning.

The solution presented here is to add an additional option for this type of event.