### PR TITLE
fixing typo in district status state: 'pause' should be 'paused'

### DIFF
--- a/lib/clever-ruby/models/district_status.rb
+++ b/lib/clever-ruby/models/district_status.rb
@@ -133,7 +133,7 @@ module Clever
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      state_validator = EnumAttributeValidator.new('String', ["running", "pending", "error", "pause"])
+      state_validator = EnumAttributeValidator.new('String', ["running", "pending", "error", "paused"])
       return false unless state_validator.valid?(@state)
       return true
     end
@@ -141,7 +141,7 @@ module Clever
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] state Object to be assigned
     def state=(state)
-      validator = EnumAttributeValidator.new('String', ["running", "pending", "error", "pause"])
+      validator = EnumAttributeValidator.new('String', ["running", "pending", "error", "paused"])
       unless validator.valid?(state)
         fail ArgumentError, "invalid value for 'state', must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
From the API https://dev.clever.com/v1.2/reference#getdistrictstatus

The district status should be "paused" but was "pause"