### PR TITLE
Revert json dependency and requirement for Ruby 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ZenTest (4.11.1)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.4.0)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
     autotest-fsevent (0.2.12)
@@ -23,9 +22,8 @@ GEM
     ethon (0.10.1)
       ffi (>= 1.3.0)
     ffi (1.9.18)
-    hashdiff (0.3.5)
+    hashdiff (0.3.6)
     json (1.8.6)
-    public_suffix (2.0.5)
     rake (12.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -55,6 +53,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.4.0)
   autotest (~> 4.4, >= 4.4.6)
   autotest-fsevent (~> 0.2, >= 0.2.12)
   autotest-growl (~> 0.2, >= 0.2.16)
@@ -63,7 +62,4 @@ DEPENDENCIES
   rake (~> 12.0.0)
   rspec
   vcr (~> 3.0, >= 3.0.1)
-  webmock (~> 1.24, >= 1.24.3)
-
-BUNDLED WITH
-   1.13.6
+  webmock (~> 1.24.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    clever-ruby (1.2.2)
-      json (~> 2.1, >= 2.1.0)
+    clever-ruby (1.2.3)
+      json (~> 1.8, >= 1.8.3)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
@@ -23,8 +23,8 @@ GEM
     ethon (0.10.1)
       ffi (>= 1.3.0)
     ffi (1.9.18)
-    hashdiff (0.3.4)
-    json (2.1.0)
+    hashdiff (0.3.5)
+    json (1.8.6)
     public_suffix (2.0.5)
     rake (12.0.0)
     rspec (3.6.0)

--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
   s.description = "The Clever API"
   # TODO uncommnet and update below with a proper license 
   #s.license     = "Apache 2.0"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.0"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -26,14 +26,15 @@ Gem::Specification.new do |s|
   s.description = "The Clever API"
   # TODO uncommnet and update below with a proper license 
   #s.license     = "Apache 2.0"
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
-  s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
+  s.add_development_dependency 'addressable',  '~> 2.4.0'
+  s.add_development_dependency 'webmock',  '~> 1.24.6'
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'


### PR DESCRIPTION
Reverts an unnecessary upgrade to the json dependency (the change came from using swagger-codegen to re-generate the library).

Also since we auto-generated the library we've actually required Ruby 2.0, but I've locked the version of addressable so we can continue to support Ruby 1.9