### PR TITLE
PLS-2897 support ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3 (2022-01-21)
+
+* Support ruby 3.x
+
 ## 2.0.2 (2019-01-03)
 
 * Relax json dependency

--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -28,8 +28,9 @@ Gem::Specification.new do |s|
   #s.license     = "Apache 2.0"
   s.required_ruby_version = ">= 1.8"
 
-  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'addressable', '~> 2.8'
   s.add_runtime_dependency 'json', ">= 1.8", "< 3"
+  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '>= 3.0.1', '~> 5.0'

--- a/lib/clever-ruby/api_client.rb
+++ b/lib/clever-ruby/api_client.rb
@@ -289,7 +289,7 @@ module Clever
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/clever-ruby/configuration.rb
+++ b/lib/clever-ruby/configuration.rb
@@ -175,7 +175,7 @@ module Clever
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.escape(url)
     end
 
     # Gets API key (with prefix if set).

--- a/override/api_client.rb
+++ b/override/api_client.rb
@@ -289,7 +289,7 @@ module Clever
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body


### PR DESCRIPTION
- Use Addressable::URI.escape instead of deprecated URI.encode

#### Jira ticket
https://teamsatchel.atlassian.net/browse/PLS-2897